### PR TITLE
Possible fix for when `axis.title.y` is set globally with `theme_update()`

### DIFF
--- a/R/simpleUpSet.R
+++ b/R/simpleUpSet.R
@@ -213,9 +213,9 @@ simpleUpSet <- function(
         axis.ticks.x.bottom = element_blank(),
         axis.text.x = element_blank(),
         axis.title.x = element_blank(),
-        axis.title.y = element_text(vjust = -vj),
         margins = margin(0, 5.5, 5.5, 0)
-      )
+      ) +
+          .theme_axis_title_y_vjust(-vj)
     }
   )
 }
@@ -342,7 +342,7 @@ simpleUpSet <- function(
 
   ## Add the vjust as a new theme
   n_layers <- length(layers)
-  layers[[n_layers + 1]] <- theme(axis.title.y = element_text(vjust = -vj))
+  layers[[n_layers + 1]] <- .theme_axis_title_y_vjust(-vj)
 
   ## The intial plot
   p <- ggplot(tbl)
@@ -524,6 +524,15 @@ simpleUpSet <- function(
     is_theme(x), is_scale(x), is_position(x), is_guides(x), is_layer(x),
     is_mapping(x), is_coord(x), is_stat(x), is_facet(x)
   )
+}
+
+#' @keywords internal
+#' @import ggplot2
+.theme_axis_title_y_vjust <- function(vj){
+    el <- theme_get()$axis.title.y
+    if (is.null(el)) el <- element_text()
+    el$vjust <- vj
+    theme(axis.title.y = el)
 }
 
 ## Key options to develop


### PR DESCRIPTION
Hey Stevie,

Loving `SimpleUpset`! Came across a small issue when `ggplot2::theme_update()` is used to set `axis.title.y` prior to plotting. See reprex below:

``` r
library(tidyverse)
library(ggtext)
library(SimpleUpset)
#> Loading required package: patchwork
theme_update(axis.title.y = element_markdown())
movies <- system.file("extdata", "movies.tsv.gz", package = "SimpleUpset") %>%
    read_tsv() %>%
    mutate(
        Decade = fct_inorder(Decade) %>% fct_rev()
    )
#> Rows: 3883 Columns: 10
#> ── Column specification ────────────────────────────────────────────────────────
#> Delimiter: "\t"
#> chr (2): Name, Decade
#> dbl (8): ReleaseDate, Action, Comedy, Drama, Thriller, Romance, AvgRating, W...
#> 
#> ℹ Use `spec()` to retrieve the full column specification for this data.
#> ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message.
sets <- c("Action", "Comedy", "Drama", "Thriller", "Romance")
simpleUpSet(movies, sets)
#> Error in `plot_theme()`:
#> ! Can't merge the `axis.title.y` theme element.
#> Caused by error in `method(merge_element, list(ggplot2::element, class_any))`:
#> ! Only elements of the same class can be merged.
```

<sup>Created on 2026-04-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

This PR seems to fix the issue by preserving the existing theme element class and only modifying its `vjust`. Posting this as a heads-up really, as I'm not fully around the codebase of `SimpleUpset` and you may have a more elegant solution. See what you think :)